### PR TITLE
Add meta app-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,6 @@
 
 ## ~v 0.4.0 - Deprecated~
 
-* *Won't install, does not set `APP_LABEL`
+* *Won't install, does not set `APP_LABEL`*
 * Supports Django up to Django 1.11.
 * Breaking change – May not support Django 1.7 (untested). Use v 0.3.7 if necessary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v 0.4.1 - Deprecated
+## v 0.4.1
 
 * Add `meta app_label`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
-## v 0.4.0
+## v 0.4.1 - Deprecated
 
+* Add `meta app_label`
+
+## ~v 0.4.0 - Deprecated~
+
+* *Won't install, does not set `APP_LABEL`
 * Supports Django up to Django 1.11.
 * Breaking change – May not support Django 1.7 (untested). Use v 0.3.7 if necessary.

--- a/djangoratings/__init__.py
+++ b/djangoratings/__init__.py
@@ -1,7 +1,7 @@
 import os.path
 import warnings
 
-__version__ = (0, 4, 0)
+__version__ = (0, 4, 1)
 
 def _get_git_revision(path):
     revision_file = os.path.join(path, 'refs', 'heads', 'master')

--- a/djangoratings/managers.py
+++ b/djangoratings/managers.py
@@ -30,6 +30,10 @@ class VoteQuerySet(QuerySet):
 
 
 class VoteManager(Manager):
+
+    class Meta:
+        app_label = 'djangoratings'
+
     def get_query_set(self):
         return VoteQuerySet(self.model)
 
@@ -48,6 +52,10 @@ class VoteManager(Manager):
 
 
 class SimilarUserManager(Manager):
+
+    class Meta:
+        app_label = 'djangoratings'
+
     def get_recommendations(self, user, model_class, min_score=1):
         from djangoratings.models import Vote, IgnoredObject
 

--- a/djangoratings/models.py
+++ b/djangoratings/models.py
@@ -33,6 +33,7 @@ class Vote(models.Model):
     content_object = GenericForeignKey()
 
     class Meta:
+        app_label = 'djangoratings'
         unique_together = (('content_type', 'object_id', 'key', 'user', 'ip_address', 'cookie'))
 
     def __unicode__(self):
@@ -64,6 +65,7 @@ class Score(models.Model):
     content_object  = GenericForeignKey()
 
     class Meta:
+        app_label = 'djangoratings'
         unique_together = (('content_type', 'object_id', 'key'),)
 
     def __unicode__(self):
@@ -79,6 +81,7 @@ class SimilarUser(models.Model):
     objects = SimilarUserManager()
 
     class Meta:
+        app_label = 'djangoratings'
         unique_together = (('from_user', 'to_user'),)
 
     def __unicode__(self):
@@ -92,6 +95,7 @@ class IgnoredObject(models.Model):
     content_object = GenericForeignKey()
 
     class Meta:
+        app_label = 'djangoratings'
         unique_together = (('content_type', 'object_id'),)
 
     def __unicode__(self):


### PR DESCRIPTION
was getting 
```
build            │   File "/usr/local/lib/python2.7/site-packages/django/db/models/base.py", line 102, in __new__
build            │     "INSTALLED_APPS." % (module, name)
build            │ RuntimeError: Model class djangoratings.models.Vote doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```

added explict `app_label`